### PR TITLE
Use_S3_for_image_upload

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -5,6 +5,7 @@ set :application, "sagojo"
 set :repo_url, "git@github.com:yuta-gunji/sagojo.git"
 
 set :linked_dirs, fetch(:linked_dirs, []).push('log', 'tmp/pids', 'tmp/cache', 'tmp/sockets', 'vendor/bundle', 'public/system', 'public/uploads')
+set :linked_files, %w{ config/secrets.yml }
 
 set :rbenv_type, :user
 set :rbenv_ruby, '2.3.1'


### PR DESCRIPTION
# what
画像のアップロード先をAWSのS3に変更する。
# why
アプリケーションに負荷をかけないようにするため。